### PR TITLE
func makeCalc was created

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "GPL-3.0",
   "devDependencies": {
     "@mate-academy/eslint-config": "*",
-    "@mate-academy/scripts": "^0.7.12",
+    "@mate-academy/scripts": "^1.2.8",
     "eslint": "^5.16.0",
     "eslint-plugin-jest": "^22.4.1",
     "eslint-plugin-node": "^8.0.1",

--- a/src/makeCalculator.js
+++ b/src/makeCalculator.js
@@ -37,7 +37,32 @@
  * @return {object}
  */
 function makeCalculator() {
-  // write code here
+  return {
+    result: 0,
+    add(number, result) {
+      return result + number;
+    },
+    subtract(number, result) {
+      return result - number;
+    },
+    multiply(number, result) {
+      return result * number;
+    },
+    divide(number, result) {
+      return result / number;
+    },
+    operate(action, value) {
+      this.result = action(value, this.result);
+
+      return this;
+    },
+    reset() {
+      this.result = 0;
+
+      return this;
+    },
+
+  };
 }
 
 module.exports = makeCalculator;


### PR DESCRIPTION
Немає розуміння чому коли звертаєшся до this в функціях  add, subtract, multiply, divide там в якості об’єкту Window а не об’єкт який ми створили. Можливо є якесь посилання де про це пишуть.   
Наприкладі мого коду. Перевірка calculator.operate(calculator.add, 3); 
 Відбувається виклик функції operate(action, value) {
      this.result = action(value, this.result); 
  в якості параметру action передається calculator.add 
По моїм міркуванням 55 стрічка   this.result = action(value, this.result);  уявно виглядає як: 
this.result = calculator.add (value, this.result); 
Тобто зліва від   .add стоїть calculator, і в моєму розумінні, в такому випадку в середині визваної функції add,  ключове слово this - має бути посилання на calculator а не на загальний window.  Адже const calculator = makeCalculator(); де  makeCalculator() функція яка повертає наш створений об’єкт.   