### PR TITLE
made calculator

### DIFF
--- a/src/makeCalculator.js
+++ b/src/makeCalculator.js
@@ -37,7 +37,51 @@
  * @return {object}
  */
 function makeCalculator() {
-  // write code here
+  let result = 0;
+
+  const calc = {
+    add: function(number) {
+      result += number;
+
+      return this;
+    },
+
+    subtract: function(number) {
+      result -= number;
+
+      return this;
+    },
+
+    multiply: function(number) {
+      result *= number;
+
+      return this;
+    },
+
+    divide: function(number) {
+      result /= number;
+
+      return this;
+    },
+
+    reset: function(number) {
+      result = 0;
+
+      return this;
+    },
+
+    operate: function(callback, number) {
+      callback(number);
+
+      return this;
+    },
+
+    get result() {
+      return result;
+    },
+  };
+
+  return calc;
 }
 
 module.exports = makeCalculator;


### PR DESCRIPTION
why when I used arrow function expressions in variable calc instead of function(), I had this fail in the test: 
sum > 'operate' should correctly work in a long chain
-----
TypeError: Cannot read property 'operate' of undefined